### PR TITLE
Remove unused links

### DIFF
--- a/troposphere/templates/index.html
+++ b/troposphere/templates/index.html
@@ -181,8 +181,6 @@
     {% else %}
     {% render_bundle 'app' 'js' %}
     {% endif %}
-    <!-- Google Analytics -->
-    {% render_bundle 'analytics' 'js' %}
 {% else %}
     <script src="{{ BASE_URL }}/assets/bundles/manifest.js"></script>
     <script src="{{ BASE_URL }}/assets/bundles/vendor.js"></script>
@@ -191,8 +189,6 @@
     {% else %}
     <script src="{{ BASE_URL }}/assets/bundles/app.js"></script>
     {% endif %}
-    <!-- Google Analtics -->
-    <script src="{{ BASE_URL }}/assets/bundles/analytics.js"></script>
 {% endif %}
 </body>
 </html>


### PR DESCRIPTION
typo on the branch name, just saying. 

I decide to keep the file:  `troposphere/static/js/analytics.js` for now. 
Just in case, in the future, we would use google analytics to help us keep track of user traffics

- [x] Remove analytics links
- [x] Remove raven JS links and intercom JS links (other PRs by Rob)
- [ ] Remove cyverse links