### PR TITLE
fix missing python lib imported from default

### DIFF
--- a/troposphere/settings/__init__.py
+++ b/troposphere/settings/__init__.py
@@ -1,4 +1,5 @@
+from troposphere.settings.default import *
 try:
-    import troposphere.settings.local
+    from troposphere.settings.local import *
 except ImportError:
     raise Exception("No local settings module found. Refer to README.md")


### PR DESCRIPTION
Without importing packages from `troposphere/setting/default.py`, it will throw an error and that is because we don't `import os`