### PR TITLE
Comment out the volume in the project resource page

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/ProjectDetails.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/ProjectDetails.jsx
@@ -140,12 +140,14 @@ export default React.createClass({
                         onPreviewResource={this.onPreviewResource}
                         previewedResource={previewedResource}
                         selectedResources={selectedResources} />
+                    {/*
                     <VolumeList volumes={projectVolumes}
                         onResourceSelected={this.onResourceSelected}
                         onResourceDeselected={this.onResourceDeselected}
                         onPreviewResource={this.onPreviewResource}
                         previewedResource={previewedResource}
                         selectedResources={selectedResources} />
+                    */}
                     <ImageList images={projectImages}
                         onResourceSelected={this.onResourceSelected}
                         onResourceDeselected={this.onResourceDeselected}

--- a/troposphere/static/js/components/projects/detail/resources/SubMenu.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/SubMenu.jsx
@@ -42,9 +42,9 @@ export default React.createClass({
                     <li>
                         <a id="res-create-instance" href="#" onClick={this.onCreateInstance}><i className={'glyphicon glyphicon-tasks'} /> Instance</a>
                     </li>
-                    <li>
+                    {/*<li>
                         <a id="res-create-volume" href="#" onClick={this.onCreateVolume}><i className={'glyphicon glyphicon-hdd'} /> Volume</a>
-                    </li>
+                    </li>*/}
                     <li>
                         <a id="res-create-link" href="#" onClick={this.onCreateExternalLink}><i className={'glyphicon glyphicon-globe'} /> Link</a>
                     </li>


### PR DESCRIPTION
Commenting out volume part in two files. The reason why it is commenting not deleting is because we still need the volume service enabled in the future sprints. Temporarily hiding it in the interface for the OpenStack Summit.